### PR TITLE
Fix # 223 Button background color

### DIFF
--- a/sbs_utils/mast/parsers.py
+++ b/sbs_utils/mast/parsers.py
@@ -153,6 +153,8 @@ class StyleDefinition:
                     ret[key]=StyleDefinition.parse_bounds(value)
                 case "background":
                     ret[key]=value
+                case "background-color":
+                    ret[key]=value
                 case "background-image":
                     ret[key]=value
                 case "border-image":

--- a/sbs_utils/pages/layout/button.py
+++ b/sbs_utils/pages/layout/button.py
@@ -1,5 +1,6 @@
 from .column import Column
 from ...helpers import FrameContext
+from .bounds import Bounds
 
 class Button(Column):
     def __init__(self, tag, message) -> None:
@@ -11,13 +12,47 @@ class Button(Column):
         else:
             self.message = message
 
+    def _pre_present(self, event):
+        # This eliminates the issue of the Column#_pre_present() where it makes a background that isn't the button.
+        ctx = FrameContext.context
+        if self.background_color is not None:
+            bg = Bounds(self.bounds)
+            bg.grow(self.padding)
+            # NOTE: sbs.send_gui_colorbutton uses the `color` parameter for the background color.
+            # If there's a better way to do this, feel free to make it so. But it works great as is.
+            # What we're doing is swapping out any existing `color` attributes and adding a new one, with the value for self.background_color.
+            import re
+            button_message = re.sub(r"[^-]color:.*?(;|$)","",self.message, flags=re.M) # This removes any existing color tag, which is used for text color, but in this case we need it for the backgorund color
+            button_message = f"color:{self.background_color};{button_message}" # Prepend instead of append so we don't need to depend on user to include a tailing semicolon
+            # This color button is now effectively the background.
+            ctx.sbs.send_gui_colorbutton(event.client_id, self.region_tag,
+                self.tag, button_message, 
+                bg.left, bg.top, bg.right, bg.bottom)
+
+
     def _present(self,  event):
         ctx = FrameContext.context
         message = self.message
         message += self.get_cascade_props(True, True, True)
-        ctx.sbs.send_gui_button(event.client_id, self.region_tag,
-            self.tag, message, 
-            self.bounds.left, self.bounds.top, self.bounds.right, self.bounds.bottom)
+        
+        if self.background_color is None:
+            ctx.sbs.send_gui_button(event.client_id, self.region_tag,
+                self.tag, message, 
+                self.bounds.left, self.bounds.top, self.bounds.right, self.bounds.bottom)
+        else:
+            # Since background-color is specified, we have to do this a bit differently.
+            # sbs.send_gui_button() can only change the color of the text, not the background.
+            # sbs.send_gui_colorbuttton() doesn't show any text at all, but the background color can be shown.
+            # So to have a colored backgound and text, we need to couple sbs.send_gui_colorbutton() with sbs.send_gui_text()
+            
+            if message.find("draw_layer") == -1:
+                message = "draw_layer:10000;" + message # draw layer has to be high or the button covers the text
+
+            # TODO: Find a way to use padding so the text isn't righ up close to the edge of the button's border.
+            ctx.sbs.send_gui_text(event.client_id, self.region_tag,
+                self.tag+"_text", message, 
+                self.bounds.left, self.bounds.top, self.bounds.right, self.bounds.bottom)
+            
         
 
     def update(self, message):

--- a/sbs_utils/procedural/gui/button.py
+++ b/sbs_utils/procedural/gui/button.py
@@ -49,10 +49,32 @@ def gui_button(props, style=None, data=None, on_press=None, is_sub_task=False):
     """Add a gui button
 
     Args:
-        count (int): The number of columns to use
-        style (_type_, optional): Style. Defaults to None.
+        props (str): Properties. Usually just the text on the button
+        style (str, optional): Style. Defaults to None. End each style with a semicolon, e.g. `color:red;`
         data (object): The data to pass to the button's label
         on_press (label, callable, Promise): Handle a button press, label is jumped to, callable is called, Promise has results set
+
+    Valid Styles:
+        area: 
+            Format as `top, left, bottom, right`. 
+            Just numbers indicates percentage of the section or page to cover. 
+            Can also use `px` (pixels) or `em` (1em = height of text font)
+        color:
+            The color of the text
+        background-color:
+            The background color of the button
+        padding:
+            A gap inside the element (makes the button smaller, but the background still is there.)
+        margin: 
+            The gap outside the element (makes the button smaller). 
+        col-width: 
+            The width of the button
+        justify:
+            Where the text is placed inside the button. `left`, `center`, or `right`
+        font:
+            The font to use. Overrides the font in prefernces.json
+        
+        
 
     Returns:
         layout object: The Layout object created


### PR DESCRIPTION
This is somewhat of a hack, but it works pretty well IMHO. The Button class now presents a gui_colorbutton, which is just a colored button that doesn't take a text property. This is coupled with a gui_text, which is the text.