### PR TITLE
One possible fix to issue #569 - saniitize text for text input gui element

### DIFF
--- a/sbs_utils/pages/layout/text_input.py
+++ b/sbs_utils/pages/layout/text_input.py
@@ -30,7 +30,11 @@ class TextInput(Column):
         
     def on_message(self, event):
         if event.sub_tag == self.tag:
-            self.value = event.value_tag
+            sanitized_text = re.sub(r"[^A-Za-z0-9 \-_']", "", event.value_tag)
+            self.value = sanitized_text
+            if sanitized_text != event.value_tag:
+                self.mark_visual_dirty()
+        
         super().on_message(event)
         
     @property

--- a/sbs_utils/procedural/gui/input.py
+++ b/sbs_utils/procedural/gui/input.py
@@ -1,6 +1,8 @@
 from ...helpers import FrameContext
 from ..style import apply_control_styles
 from ...pages.layout.text_input import TextInput
+import re
+
 def gui_input(props, style=None, var=None, data=None):
     """ Draw a text type in
 
@@ -29,7 +31,10 @@ def gui_input(props, style=None, var=None, data=None):
         val = task.get_variable(var, "")
 
     if "$text:" not in props:
-        props = f"$text:{val};{props}"
+        sanitized_text = re.sub(r"[^A-Za-z0-9 \-_']", "", val)
+        if var is not None and sanitized_text != val:
+            task.set_variable(var, sanitized_text)
+        props = f"$text:{sanitized_text};{props}"
 
     layout_item = TextInput(tag, props)
     layout_item.data = data


### PR DESCRIPTION
This does introduce different bugs with re-presenting text input elements.
Most text fields seem to work okay, but the "Minutes" field in the server
setup menu doesn't seem to represent itself when it's marked dirty. Instead,
Characters that were removed from the text keep displaying, and possibly
overlap with other characters, until something else triggers gui refresh.
I think it's because the minutes field is inside a list box, and so this
runs into issue #349, or at least something similar.

I think fixing the more severe #569 is worth the tradeoff of introducing
the relatively tame #349. #349 could be fixed separately later.

But there might be better solutions, such as making the engine handle
sanitization instead, which would probably be more reliable and performant.