### PR TITLE
Updates to torpedo helpers

### DIFF
--- a/mkdocs/docs/mast/ai/brains.md
+++ b/mkdocs/docs/mast/ai/brains.md
@@ -1,0 +1,270 @@
+# Brains
+
+Brains are a lightweight behavior tree system used by {{ab.m}} labels.
+
+In practice, a brain:
+
+- picks one or more labels to run every tick
+- interprets each label result as success or fail
+- combines child results with selector or sequence rules
+- stores useful blackboard-style values in agent inventory
+
+If you are familiar with behavior trees:
+
+- SEL is a selector (first child success wins)
+- SEQ is a sequence (all children must succeed)
+- a normal label is a leaf node
+
+
+## Mental model
+
+Each agent can have one root brain object in inventory key __BRAIN__.
+
+The root is usually a selector:
+
+- SEL root
+	- child 1 (leaf or composite)
+	- child 2 (leaf or composite)
+	- ...
+
+Each tick:
+
+1. The brain system visits every agent that has __BRAIN__.
+2. The root brain runs.
+3. Composite nodes execute children.
+4. Leaf nodes execute a {{ab.m}} label and return a poll result.
+
+Brains do not have a permanent done state. They are evaluated repeatedly.
+
+
+## How results drive behavior
+
+Brains use success/fail-style outcomes:
+
+- PollResults.BT_SUCCESS
+- PollResults.BT_FAIL
+- PollResults.OK_IDLE (used as reset/neutral state internally)
+
+Composite behavior:
+
+- Selector (SEL):
+	- starts as fail
+	- runs children in order
+	- first child that succeeds makes selector succeed
+	- if none succeed, selector fails
+- Sequence (SEQ):
+	- runs children in order
+	- first child that fails makes sequence fail
+	- if all succeed, sequence succeeds
+
+### Result modifiers
+
+The runtime also supports modifier flags on a brain node:
+
+- Invert
+- AlwayFail
+- AlwaySuccess
+
+These flags alter the final node result after execution.
+
+
+## Leaf label execution rules
+
+A simple brain node points at one major label.
+
+When a leaf runs:
+
+1. On first run only, if sub label enter exists, it is executed once.
+2. If sub label test exists, that sub label is executed for result.
+3. Otherwise, execution starts at location 0 of the major label.
+
+Runtime variables injected for the label task:
+
+- BRAIN: current brain object
+- BRAIN_AGENT: object form of the agent id
+- BRAIN_AGENT_ID: raw agent id
+
+This is why most brain labels read/write inventory through BRAIN_AGENT.
+
+
+## Defining brains declaratively
+
+Brains can be assembled from Python-friendly structures.
+
+Supported structures:
+
+- string: label name
+- MastNode: direct label node
+- list: add each item as child
+- dict:
+	- single key starting with SEL -> selector composite
+	- single key starting with SEQ -> sequence composite
+	- otherwise use keys label and data
+
+Common pattern:
+
+```yaml
+brain:
+	SEQ:
+		- ai_fleet_init_blackboard
+		- SEL:
+			- ai_fleet_chase_best_anger
+			- label: ai_fleet_chase_roles
+				data:
+					test_roles: station
+			- label: ai_fleet_chase_roles
+				data:
+					test_roles: __player__
+		- ai_fleet_calc_forward_vector
+		- ai_fleet_scatter_formation
+```
+
+Notes:
+
+- Child order matters for SEL and SEQ.
+- data on a node is passed into the task context for that label.
+- metadata defaults in the label and runtime data overrides are often used together.
+
+
+## Quick start: attach a brain
+
+Brains are typically attached from Python when spawning/configuring an NPC or fleet controller.
+
+```py
+from sbs_utils.procedural.brain import brain_add
+
+brain_add(
+	agent_id,
+	{
+		"SEQ main": [
+			"ai_fleet_init_blackboard",
+			{
+				"SEL choose_target": [
+					"ai_fleet_chase_best_anger",
+					{"label": "ai_fleet_chase_roles", "data": {"test_roles": "station"}},
+					{"label": "ai_fleet_chase_roles", "data": {"test_roles": "__player__"}},
+				]
+			},
+			"ai_fleet_calc_forward_vector",
+			"ai_fleet_scatter_formation",
+		]
+	},
+	client_id=0,
+)
+```
+
+The first call creates a default selector root if needed, then inserts your tree.
+
+
+## Metadata and per-node data
+
+A brain label often declares defaults in metadata.
+
+Example:
+
+```mast
+=== ai_fleet_chase_roles
+metadata: yaml
+	type: brain/npc
+	use_arena: True
+	test_roles: station
+	exclude_roles: raider
+		...
+```
+
+Then a brain node can provide data overrides:
+
+```yaml
+label: ai_fleet_chase_roles
+data:
+	test_roles: __player__
+```
+
+This allows one label to be reused with different behavior.
+
+
+## Active brain status text
+
+The runtime tracks active text for debugging/UI use.
+
+For a leaf node:
+
+- active: label name
+- active_desc:
+	- desc inventory value if present
+	- optionally random choice if desc is a list
+	- then DisplayName inventory value if present
+	- otherwise label name
+
+For a selector, when one child succeeds:
+
+- that child becomes active
+- brain_active inventory is set to child active_desc
+
+
+## Worked example: fleet brain
+
+Using your fleet script shape:
+
+1. ai_fleet_init_blackboard
+	- resets target data
+	- computes lead ship and local arena
+2. SEL target choice
+	- try ai_fleet_chase_best_anger first
+	- if that fails, try role-based targeting variants
+3. ai_fleet_calc_forward_vector
+	- computes destination and throttle
+4. ai_fleet_scatter_formation
+	- issues per-ship target positions
+
+This creates robust fallback logic:
+
+- preferred tactical behavior first
+- deterministic fallbacks second
+- movement only after a valid target exists
+
+
+## Minimal authoring checklist
+
+When writing a new brain label:
+
+1. Add metadata defaults for tunables (distance, roles, stop_dist, etc.).
+2. Use BRAIN_AGENT inventory as your blackboard.
+3. Return early with yield fail when prerequisites are missing.
+4. Set outputs (target, target_position, throttle, etc.).
+5. End with yield success.
+
+When composing a tree:
+
+1. Use SEQ for required steps.
+2. Use SEL for fallback options.
+3. Put cheap/high-confidence options earlier.
+4. Keep each label focused on one responsibility.
+
+
+## Debugging tips
+
+- If a brain seems idle, verify the agent has __BRAIN__ assigned.
+- If a label never runs, confirm the label name resolves correctly.
+- If selector never succeeds, inspect each child for missing prerequisites.
+- If targeting stalls, verify blackboard keys are populated in init step.
+- Track brain_active to see which child is currently winning selection.
+
+
+## API touchpoints
+
+Core procedural calls:
+
+- brain_add(...)
+- brain_clear(...)
+- brains_run_all(...)
+
+These are defined in:
+
+- sbs_utils/procedural/brain.py
+
+Example mission labels:
+
+- fleets/brain_fleet.mast
+
+Together they provide a full pattern for authoring reusable NPC decision logic.

--- a/mkdocs/docs/mast/ai/index.md
+++ b/mkdocs/docs/mast/ai/index.md
@@ -1,0 +1,76 @@
+# AI Overview
+
+AI in {{ab.m}} is about giving non-player entities clear, repeatable decision logic.
+
+At a high level, AI scripts decide:
+
+- what an agent should target
+- where it should move
+- what action it should take next
+- what to do if the preferred action is not possible
+
+The system is designed to be practical for mission authors:
+
+- behavior is split into small labels with focused responsibilities
+- data is stored in agent inventory (a simple blackboard pattern)
+- decisions can be composed with selectors and sequences
+- logic runs incrementally with the engine tick model
+
+
+## Core AI building blocks
+
+Most mission AI uses a combination of these pieces:
+
+1. Route labels
+	Route labels (such as spawn-related routes) are commonly used to initialize AI when objects appear.
+2. Tasks
+	Tasks run behavior logic over time, yielding when waiting for conditions or time.
+3. Brains
+	Brains provide behavior-tree style composition so you can build fallback and ordered logic.
+4. Inventory blackboard
+	AI labels share state through inventory keys like target, target_position, threat, cooldowns, and role-based data.
+
+
+## Typical AI workflow
+
+For most NPC or fleet behaviors, authoring follows this pattern:
+
+1. Initialize context
+	Collect local data (lead ship, nearby entities, zones, constraints).
+2. Choose intent
+	Decide what to do next (chase, defend, retreat, idle).
+3. Compute output
+	Produce movement/action outputs (target, throttle, destination, action flags).
+4. Execute command
+	Apply movement/combat commands to controlled entities.
+5. Repeat each tick
+	Re-evaluate based on changing world state.
+
+
+## Why brains are useful
+
+As behavior gets more complex, plain single-label logic becomes hard to maintain.
+Brains help by making intent explicit:
+
+- Sequence (SEQ) for required ordered steps
+- Selector (SEL) for fallback options
+- Reusable leaf labels with metadata defaults and per-node overrides
+
+This keeps AI easier to read, debug, and extend over time.
+
+
+## Design goals for mission AI
+
+Good mission AI is usually:
+
+- understandable: each label does one job
+- resilient: has fallback behavior when data is missing
+- data-driven: tunables come from metadata and node data
+- inspectable: active behavior and blackboard values can be observed
+
+
+## Next step
+
+For the full behavior-tree tutorial and concrete examples, see the brains guide:
+
+- [Brains Tutorial](brains.md)

--- a/mkdocs/docs/mast/ai/simple.md
+++ b/mkdocs/docs/mast/ai/simple.md
@@ -1,0 +1,1 @@
+# Simple AI

--- a/mkdocs/docs/mast/objectives.md
+++ b/mkdocs/docs/mast/objectives.md
@@ -1,0 +1,235 @@
+# Objectives
+
+The objectives system is a lightweight way to run mission goals over time.
+
+An objective is a label-driven task attached to an agent. It is polled by the shared scheduler until it completes, then it is automatically cleaned up.
+
+
+## What objectives are for
+
+Use objectives when you want stateful goal logic such as:
+
+- defend this station until reinforcements arrive
+- escort a ship to a destination
+- watch for mission fail/win conditions
+- run per-agent progress checks that can complete independently
+
+Compared to a one-off task, an objective gives you:
+
+- a standard lifecycle (enter, test/main, leave)
+- automatic registration and cleanup
+- links/roles that make active objectives queryable
+
+
+## Runtime model
+
+The system schedules one shared tick task with objective_schedule().
+
+That scheduler rotates work across ticks:
+
+1. objectives_run_all + expired modifier cleanup
+2. brains_run_all
+3. extra scan sources + game end conditions
+
+This spreads workload instead of running every subsystem every tick.
+
+
+## Objective lifecycle
+
+Each Objective instance stores:
+
+- target agent id
+- label to run
+- optional data payload
+- client id (for GUI-task scoped execution)
+- current result and done state
+
+Lifecycle flow:
+
+1. Objective is added and linked to the owning agent.
+2. Optional sub label enter runs once on first execution.
+3. If sub label test exists, test is run each objective pass.
+4. Otherwise, execution starts at label location 0.
+5. Objective completes when result is no longer OK_IDLE.
+6. Optional sub label leave runs on completion/stop.
+7. Roles/links are removed automatically.
+
+
+## Label contract
+
+Objective labels should follow a simple contract:
+
+- return OK_IDLE while still in progress
+- return success/fail end when finished
+- keep per-objective state in inventory or provided data
+
+Runtime variables injected into objective label tasks:
+
+- OBJECTIVE: objective object instance
+- OBJECTIVE_ID: unique objective id
+- OBJECTIVE_AGENT_ID: owning agent id
+- OBJECTIVE_AGENT: owning agent object
+
+
+## Using objectives
+
+You can add objectives in several forms:
+
+- label string
+- label object
+- dict with label and optional data
+- list of labels/dicts (expanded per agent)
+
+API:
+
+```py
+objective_add(agent_id_or_set, label, data=None, client_id=0)
+```
+
+Examples:
+
+```py
+    station = closest(player_ship, role("station"),10000)
+    objective_add(ship_id, "objective_defend_station", data={"time_limit": 15, "station": station})
+```
+
+
+
+## Clearing and stopping
+
+Clear objectives for one or many agents:
+
+```py
+objective_clear(agent_or_set)
+```
+
+Internally, clearing will:
+
+- call stop_and_leave(...) on each active objective
+- run leave sub label when present
+- unlink and remove OBJECTIVE / OBJECTIVE_RUN roles
+
+
+## Objective roles and links
+
+When created, an objective is linked and marked so systems can find it:
+
+- objective has role OBJECTIVE
+- objective has role OBJECTIVE_RUN
+- agent links to objective under OBJECTIVE and OBJECTIVE_RUN
+
+These links are removed when objective ends or is force-cleared.
+
+
+
+## Enter, test, leave pattern
+
+A recommended objective label structure:
+
+```mast
+=== obj_example
+
++++ enter
+	# one-time setup
+
++++ test
+	# return idle until complete
+	yield success if some_condition
+	yield fail if some_failing_condition
+    yield idle otherwise
+
++++ leave
+	# cleanup / signals / reward payout
+```
+
+Use this pattern to keep setup, polling, and teardown easy to reason about.
+
+
+## Building an Objective
+
+You will typically build a custom objective with a few things in mind:
+- To what agent does the objective apply
+- What information could be added to metadata (for simpler customization)
+- Under what conditions is the objective completed or failed
+- What happens upon completion or failure
+
+
+In this example, the objective applies to one or more player ships.
+If the station is destroyed, the objective should fail.
+If the station is not destroyed, the objective should succeed.
+
+```mast
+=== objective_defend_station
+metadata: ```
+time_limit: 10 # minutes
+station: 
+```
++++ enter
+
+    # If station wasn't defined or included in data, then we'll find the closest one to the ship.
+    default station = closest(OBJECTIVE_AGENT_ID, role("station"))
+
+    # Check to make sure `station` is valid, otherwise we'll find the nearest station.
+    if to_object(station) is None:
+        yield fail
+    set_timer(OBJECTIVE_AGENT, "defend_time_limit", minutes=time_limit)
+
++++ test
+
+    # Check if station exists
+    if to_object(station) is None:
+        yield fail
+
+    # Check the timer
+    if is_timer_finished(OBJECTIVE_AGENT, "defend_time_limit"):
+        yield success
+
+    # Objective still in progress
+    yield idle
+
++++ leave
+
+    if OBJECTIVE.result == OK_SUCCESS:
+        blob = to_blob(station)
+        armor = blob.get("armor")
+        max_armor = blob.get("armorMax")
+        rep = armor/max_armor*5
+        modifier_add(OBJECTIVE_AGENT_ID, "reputation", rep, "Station Defended")
+        sbs.play_music_file(0, "music/default/victory")
+    else:
+        modifier_add(OBJECTIVE_AGENT_ID, "reputation", -10, "Station Destroyed")
+        sbs.play_music_file(0, "music/default/failure)
+```
+
+
+## Game end integration
+
+The objective module also contains end-game condition helpers:
+
+- game_end_condition_add(promise, message, is_win, music=None, signal=None)
+- game_end_condition_remove(id)
+
+Registered promises are polled by the shared scheduler. When a promise completes, the system:
+
+- sets shared game state flags (GAME_STARTED / GAME_ENDED)
+- sets START_TEXT
+- emits show_game_results (or custom signal)
+
+
+## Best practices
+
+1. Keep each objective focused on one mission goal.
+2. Use data/metadata for tunable values, not hardcoded constants.
+3. Return OK_IDLE only when truly waiting for future progress.
+4. Use leave for cleanup, rewards, and signaling.
+5. Prefer multiple small objectives over one monolithic label.
+
+
+## Related systems
+
+- AI brains for decision composition: [AI Brains](ai/brains.md)
+- AI overview landing page: [AI Overview](ai/index.md)
+
+Runtime implementation reference:
+
+- sbs_utils/procedural/objective.py

--- a/sbs_utils/procedural/torpedoes.py
+++ b/sbs_utils/procedural/torpedoes.py
@@ -136,6 +136,59 @@ def get_torp_string_value_dict(key:str)->dict:
     torp = get_torp_value_string(key)
     return parse_torp_string(torp)
 
+def torp_update_value(key:str, attribute_name:str, value:str):
+    """
+    Update one attribute of a specified torpedo type.
+    Args:
+        key (str): The key of the torpedo to modify.
+        attribute_name (str): The name of the attribute to modify
+        value (str): The new value for the attribute
+    """
+    torp = get_torp_string_value_dict(key)
+    torp[attribute_name] = value
+    torp_string = ""
+    for attr, val in torp:
+        torp_string = torp_string + attr + ": " + val + "; "
+    return torp_string
+
+# NOTE: Since as far as I've been able to determine, there's no way to get a list of all torpedoes 
+# defined on the server without somehow parsing the whole shared string, I figured being able to 
+# at least get all the ones for a given ship would be helpful.
+def torpedo_get_count_for_ship(id, key) -> tuple[int,int]:
+    """
+    Get the count and the maximum of the specified torpedo type for the ship.
+    Args:
+        id (int | Agent): The ship
+        key (str): The key representing the torpedo type.
+    Returns:
+        tuple[int,int] | None: The number of torpedoes and the maximum number of those torpdoes that can fit on the ship
+    """
+    obj = to_object(id)
+    if obj is not None:
+        count = get_data_set_value(id, f"{key}_NUM")
+        if count is None:
+            count = 0
+        max = get_data_set_value(id, f"{key}_MAX")
+        if max is None:
+            max = 0
+        return (count, max)
+    return (0,0)
+
+def torpedo_get_available_types_for_ship(id) -> list[str]:
+    """
+    Get a list of the keys for all the torpedo types currently available to a player ship.
+    Args:
+        id (int | Agent): The id of the ship, or the Agent representing it.
+    Returns:
+        list[str]: The list of torpedo keys.
+    """
+    obj = to_object(id)
+    if obj is not None:
+        types = get_data_set_value(id,"torpedo_types_available")
+        if isinstance(types, str):
+            type_list = types.split(",")
+            return type_list
+    return list()
 
 def torpedo_make_available(id, key:str, count:int=0) -> None:
     """

--- a/sbs_utils/procedural/torpedoes.py
+++ b/sbs_utils/procedural/torpedoes.py
@@ -47,6 +47,7 @@ def torpedo_type(
             * standard - the default behavior of damaging a single target upon hit.
             * blast - creates an area of effect with diminishing effects as the distance from the blast epicenter increases.
             * reduce_shields - reduces the shields of the target(s). (EMP)
+
         blast_radius (int, optional): How large the area of effect should be, if `warhead` has the type "blast". Default is 1000.
         damage (int, optional): The base damage dealt to the target. If `warhead` has the type "blast", damage decreases depending on the distance from the blast's epicenter. Default is 5.
         explosion_size (int, optional): The size of the explosion visual effect on the 3d view. Default is 10.
@@ -54,6 +55,7 @@ def torpedo_type(
         behaviour (str, optional): The behavior of the torpedo guidance system. Default is homing.
             * homing - the torpedo will home in on its target, compensating for movement.
             * mine - the torpedo will not move after it has been placed and will detonate when a ship gets close.
+
         energy_conversion_value (int, optional): The amount of energy to provide to the ship by disassembling the torpedo. Default is 100.
         other (str, optional): Additional arguments to add, using the format "key1:value1;key2:value2;"
     """
@@ -72,6 +74,29 @@ def torpedo_type_string(key:str, string:str):
     """
     Define a torpedo type using the values specified in the string. Values that are not included will use default values.
     E.g. if you use `torpedo_type_string("SomeTorp","gui_text:Type 42;damage:12")`, it will make a homing torpedo called the Type 42 that does 12 damage, and all the other values will be identical to a regular homing torpedo.
+    
+    The string can contain these attribute names:
+        gui_text (str, optional): The name of the torpedo as seen by the players. If None, then will be the same as the key.
+        speed (int, optional): The speed at which the torpedo moves. Default is 10.
+        lifetime (int, optional): How long (in seconds) the torpedo continues to move. Default is 25.
+        flare_color (str, optional): The color of the torpedo's exhuast flare. Default is white.
+        trail_color (str, optional): The color of the torpedo's exhaust trail. Default is white.
+        warhead (str, optional): A comma-separated string defining the behavior of the warhead upon contact. Default is standard.
+            * standard - the default behavior of damaging a single target upon hit.
+            * blast - creates an area of effect with diminishing effects as the distance from the blast epicenter increases.
+            * reduce_shields - reduces the shields of the target(s). (EMP)
+
+        blast_radius (int, optional): How large the area of effect should be, if `warhead` has the type "blast". Default is 1000.
+        damage (int, optional): The base damage dealt to the target. If `warhead` has the type "blast", damage decreases depending on the distance from the blast's epicenter. Default is 5.
+        explosion_size (int, optional): The size of the explosion visual effect on the 3d view. Default is 10.
+        explosion_color (str, optional): The color of the explosion visual effect on the 3d view. Default is "fire".
+        behaviour (str, optional): The behavior of the torpedo guidance system. Default is homing.
+            * homing - the torpedo will home in on its target, compensating for movement.
+            * mine - the torpedo will not move after it has been placed and will detonate when a ship gets close.
+
+        energy_conversion_value (int, optional): The amount of energy to provide to the ship by disassembling the torpedo. Default is 100.
+        other (str, optional): Additional arguments to add, using the format "key1:value1;key2:value2;"
+    
     Args:
         key (str): The key by which the torpodo is identified.
         string (str): The torpedo value string containing any non-default values.
@@ -138,7 +163,30 @@ def get_torp_string_value_dict(key:str)->dict:
 
 def torp_update_value(key:str, attribute_name:str, value:str|int):
     """
-    Update one attribute of a specified torpedo type.
+    Update one attribute of a specified torpedo type.  
+    Possible attibute names:  
+        key (str): The key by which the torpodo is identified.  
+        gui_text (str, optional): The name of the torpedo as seen by the players. If None, then will be the same as the key.  
+        speed (int, optional): The speed at which the torpedo moves. Default is 10.  
+        lifetime (int, optional): How long (in seconds) the torpedo continues to move. Default is 25.  
+        flare_color (str, optional): The color of the torpedo's exhuast flare. Default is white.  
+        trail_color (str, optional): The color of the torpedo's exhaust trail. Default is white.  
+        warhead (str, optional): A comma-separated string defining the behavior of the warhead upon contact. Default is standard.  
+            * standard - the default behavior of damaging a single target upon hit.  
+            * blast - creates an area of effect with diminishing effects as the distance from the blast epicenter increases.  
+            * reduce_shields - reduces the shields of the target(s). (EMP)  
+  
+        blast_radius (int, optional): How large the area of effect should be, if `warhead` has the type "blast". Default is 1000.  
+        damage (int, optional): The base damage dealt to the target. If `warhead` has the type "blast", damage decreases depending on the distance from the blast's epicenter. Default is 5.  
+        explosion_size (int, optional): The size of the explosion visual effect on the 3d view. Default is 10.  
+        explosion_color (str, optional): The color of the explosion visual effect on the 3d view. Default is "fire".  
+        behaviour (str, optional): The behavior of the torpedo guidance system. Default is homing.  
+            * homing - the torpedo will home in on its target, compensating for movement.  
+            * mine - the torpedo will not move after it has been placed and will detonate when a ship gets close.  
+  
+        energy_conversion_value (int, optional): The amount of energy to provide to the ship by disassembling the torpedo. Default is 100.  
+        other (str, optional): Additional arguments to add, using the format "key1:value1;key2:value2;"  
+    
     Args:
         key (str): The key of the torpedo to modify.
         attribute_name (str): The name of the attribute to modify
@@ -154,6 +202,29 @@ def torp_update_value(key:str, attribute_name:str, value:str|int):
 def torp_get_attribute_value(key:str, attribute_name:str) -> str:
     """
     Get the value of one attribute of a specified torpedo type.
+        Possible attibute names:  
+        key (str): The key by which the torpodo is identified.  
+        gui_text (str, optional): The name of the torpedo as seen by the players. If None, then will be the same as the key.  
+        speed (int, optional): The speed at which the torpedo moves. Default is 10.  
+        lifetime (int, optional): How long (in seconds) the torpedo continues to move. Default is 25.  
+        flare_color (str, optional): The color of the torpedo's exhuast flare. Default is white.  
+        trail_color (str, optional): The color of the torpedo's exhaust trail. Default is white.  
+        warhead (str, optional): A comma-separated string defining the behavior of the warhead upon contact. Default is standard.  
+            * standard - the default behavior of damaging a single target upon hit.  
+            * blast - creates an area of effect with diminishing effects as the distance from the blast epicenter increases.  
+            * reduce_shields - reduces the shields of the target(s). (EMP)  
+  
+        blast_radius (int, optional): How large the area of effect should be, if `warhead` has the type "blast". Default is 1000.  
+        damage (int, optional): The base damage dealt to the target. If `warhead` has the type "blast", damage decreases depending on the distance from the blast's epicenter. Default is 5.  
+        explosion_size (int, optional): The size of the explosion visual effect on the 3d view. Default is 10.  
+        explosion_color (str, optional): The color of the explosion visual effect on the 3d view. Default is "fire".  
+        behaviour (str, optional): The behavior of the torpedo guidance system. Default is homing.  
+            * homing - the torpedo will home in on its target, compensating for movement.  
+            * mine - the torpedo will not move after it has been placed and will detonate when a ship gets close.  
+  
+        energy_conversion_value (int, optional): The amount of energy to provide to the ship by disassembling the torpedo. Default is 100.  
+        other (str, optional): Additional arguments to add, using the format "key1:value1;key2:value2;"  
+    
     Args:
         key (str): The key of the torpedo to query.
         attribute_name (str): The name of the attribute to query.

--- a/sbs_utils/procedural/torpedoes.py
+++ b/sbs_utils/procedural/torpedoes.py
@@ -136,7 +136,7 @@ def get_torp_string_value_dict(key:str)->dict:
     torp = get_torp_value_string(key)
     return parse_torp_string(torp)
 
-def torp_update_value(key:str, attribute_name:str, value:str):
+def torp_update_value(key:str, attribute_name:str, value:str|int):
     """
     Update one attribute of a specified torpedo type.
     Args:
@@ -147,9 +147,21 @@ def torp_update_value(key:str, attribute_name:str, value:str):
     torp = get_torp_string_value_dict(key)
     torp[attribute_name] = value
     torp_string = ""
-    for attr, val in torp:
-        torp_string = torp_string + attr + ": " + val + "; "
-    return torp_string
+    for attr, val in torp.items():
+        torp_string += f"{attr}:{val};"
+    FrameContext.context.sbs.set_shared_string(key, torp_string)
+
+def torp_get_attribute_value(key:str, attribute_name:str) -> str:
+    """
+    Get the value of one attribute of a specified torpedo type.
+    Args:
+        key (str): The key of the torpedo to query.
+        attribute_name (str): The name of the attribute to query.
+    Returns:
+        str: The value of the attribute for that torpedo type. If the torpedo type or attribute does not exist, then None is returned.
+    """
+    torp = get_torp_string_value_dict(key)
+    return torp.get(attribute_name)
 
 # NOTE: Since as far as I've been able to determine, there's no way to get a list of all torpedoes 
 # defined on the server without somehow parsing the whole shared string, I figured being able to 
@@ -161,7 +173,7 @@ def torpedo_get_count_for_ship(id, key) -> tuple[int,int]:
         id (int | Agent): The ship
         key (str): The key representing the torpedo type.
     Returns:
-        tuple[int,int] | None: The number of torpedoes and the maximum number of those torpdoes that can fit on the ship
+        tuple[int,int]: The number of torpedoes and the maximum number of those torpdoes that can fit on the ship. If the torpedo type is not available to the ship, then (0,0) is returned.
     """
     obj = to_object(id)
     if obj is not None:


### PR DESCRIPTION
I need some feedback for additional improvements I want to make! 

In [station_torp_building.py](https://github.com/artemis-sbs/LegendaryMissions/blob/main/docking/station_torp_building.py), there's a hardcoded dictionary with build times. This is problematic because it is not easily extensible. I've been considering a few different ways to refactor this, and here's what I'm thinking:

Using the inventory system uses a lot of existing functionality, including allowing for individual stations to have modifiers to their build times for any given torpedo type (which allows for missions that increase a station's torpedo build speed!).

I would implement this similar to how torp counts are already implemented:
```python
get_inventory_value(so, "Homing_NUM")              # existing key
get_inventory_value(so, "Homing_BUILD_SPEED") # proposed new key
```

Then, instead of a dedicated `get_build_time_for()` function, a mission writer can utilze the ubiquitous `get_inventory_value()`.

When a torpedo type is created, the onus would be on the torpedo designer to assign default build speeds for different station types. I imagine something like:

```python
    torpedo_type("mk1","Mk1 Torpedo", 50)
    set_shared_variable("mk1_BUILD_SPEED_DEFAULTS", {"command": 2, "civil":1, "industry": 10, "science": 2, "default": 2})
```

I think this implementation would drastically improve the extensibility of torpedoes.

Any thoughs/feedback/other alternatives?
