### PR TITLE
docs: expand and polish all procedural API pages

### DIFF
--- a/mkdocs/docs/api/procedural/behavior.md
+++ b/mkdocs/docs/api/procedural/behavior.md
@@ -1,4 +1,4 @@
-# The behavior tree system
+﻿# The behavior tree system
 
 Composable behavior tree nodes for NPC AI using MAST labels as leaf nodes.
 
@@ -21,23 +21,22 @@ These are designed to be composed with `await` in MAST. Within a behavior tree l
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == npc_ai ==
     await bt_sel(attack_if_close, patrol)
 
     == attack_if_close ==
-    ~~ enemies = broad_test_around(get_pos(BRAIN_AGENT_ID), 1000) & role("enemy") ~~
-    ~~ if len(enemies) == 0: BT_FAIL ~~
-    ~~ target(BRAIN_AGENT_ID, closest(BRAIN_AGENT_ID, enemies)) ~~
-    ~~ BT_SUCCESS ~~
-
+    enemies = broad_test_around(get_pos(BRAIN_AGENT_ID), 1000) & role("enemy")
+    if len(enemies) == 0: BT_FAIL
+    target(BRAIN_AGENT_ID, closest(BRAIN_AGENT_ID, enemies))
+    BT_SUCCESS
     == patrol ==
-    ~~ target_pos(BRAIN_AGENT_ID, waypoint_x, 0, waypoint_z) ~~
-    ~~ BT_SUCCESS ~~
+    target_pos(BRAIN_AGENT_ID, waypoint_x, 0, waypoint_z)
+    BT_SUCCESS
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.behavior import bt_seq, bt_sel, bt_invert, bt_until_success
 
@@ -56,9 +55,9 @@ These are designed to be composed with `await` in MAST. Within a behavior tree l
 Within a behavior tree leaf label, end with one of:
 
 ```
-~~ BT_SUCCESS ~~   # this node succeeded
-~~ BT_FAIL ~~      # this node failed
-~~ OK_IDLE ~~      # still running (yield and retry next tick)
+BT_SUCCESS   # this node succeeded
+BT_FAIL      # this node failed
+OK_IDLE      # still running (yield and retry next tick)
 ```
 
 ## API

--- a/mkdocs/docs/api/procedural/brain.md
+++ b/mkdocs/docs/api/procedural/brain.md
@@ -1,4 +1,4 @@
-# The brain system
+﻿# The brain system
 
 Behavior-tree AI for NPCs, evaluated every tick via the objective system.
 
@@ -20,23 +20,21 @@ Within a brain label you have access to `BRAIN`, `BRAIN_AGENT`, and `BRAIN_AGENT
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == setup ==
-    ~~ brain_add(ENEMY_ID, patrol_label) ~~
-    ~~ brain_add(ENEMY_ID, attack_label) ~~
-
+    brain_add(ENEMY_ID, patrol_label)
+    brain_add(ENEMY_ID, attack_label)
     == patrol_label ==
     ///test
-    ~~ if get_pos(BRAIN_AGENT_ID).distance(TARGET_POS) > 500: BT_FAIL ~~
-    ~~ BT_SUCCESS ~~
-
+    if get_pos(BRAIN_AGENT_ID).distance(TARGET_POS) > 500: BT_FAIL
+    BT_SUCCESS
     == attack_label ==
-    ~~ target(BRAIN_AGENT_ID, PLAYER_ID) ~~
-    ~~ BT_SUCCESS ~~
+    target(BRAIN_AGENT_ID, PLAYER_ID)
+    BT_SUCCESS
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.brain import brain_add, brain_clear
 

--- a/mkdocs/docs/api/procedural/cards.md
+++ b/mkdocs/docs/api/procedural/cards.md
@@ -1,4 +1,4 @@
-# The card system
+﻿# The card system
 
 Tilemap / ASCII-art map parsing for procedural world generation and room layouts.
 
@@ -10,14 +10,14 @@ A card definition assigns each character in the ASCII map to a tile type with as
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == setup ==
-    ~~ layout = card_get("station_interior") ~~
-    ~~ card_spawn(layout, offset_x=1000, offset_z=2000) ~~
+    layout = card_get("station_interior")
+    card_spawn(layout, offset_x=1000, offset_z=2000)
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.cards.card import card_get, card_spawn
 

--- a/mkdocs/docs/api/procedural/comms.md
+++ b/mkdocs/docs/api/procedural/comms.md
@@ -1,4 +1,4 @@
-# The comms system
+﻿# The comms system
 
 Send messages to player consoles and manage the comms-tree route system.
 
@@ -12,21 +12,20 @@ The comms module provides two related capabilities:
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     //comms/alien
     + "Greetings, humans."
         //comms/alien/greet
         + "We come in peace."
-            ~~ signal_emit("alliance_offered") ~~
+            signal_emit("alliance_offered")
         + "Stand down or be destroyed."
-            ~~ target(ALIEN_ID, PLAYER_SHIP_ID) ~~
-
+            target(ALIEN_ID, PLAYER_SHIP_ID)
     == patrol ==
-    ~~ comms_broadcast(SHIP_ID, "Enemy spotted at grid 7-Alpha!", "red") ~~
+    comms_broadcast(SHIP_ID, "Enemy spotted at grid 7-Alpha!", "red")
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.comms import comms_broadcast, comms_route_to
 

--- a/mkdocs/docs/api/procedural/cosmos.md
+++ b/mkdocs/docs/api/procedural/cosmos.md
@@ -1,4 +1,4 @@
-# The cosmos functions
+﻿# The cosmos functions
 
 Low-level simulation control: create, pause, and resume the game simulation.
 
@@ -12,21 +12,21 @@ These three functions wrap the engine's simulation lifecycle commands. They are 
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == lobby ==
     + "Start Mission"
-        ~~ sim_create() ~~
+        sim_create()
         jump mission_start
 
     == cutscene ==
-    ~~ sim_pause() ~~
+    sim_pause()
     "Meanwhile, on the station..."
     await delay(seconds=5)
-    ~~ sim_resume() ~~
+    sim_resume()
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.cosmos import sim_create, sim_pause, sim_resume
 

--- a/mkdocs/docs/api/procedural/data.md
+++ b/mkdocs/docs/api/procedural/data.md
@@ -1,4 +1,4 @@
-# The data module
+﻿# The data module
 
 Utilities for randomising spawn templates and other structured data dicts.
 
@@ -8,17 +8,17 @@ Utilities for randomising spawn templates and other structured data dicts.
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
-    ~~ template = {
+    template = {
         "name": ["Raider", "Marauder", "Corsair"],
         "ship": ["cruiser", "frigate", "fighter"],
-    } ~~
-    ~~ chosen = data_choose_value_from_template(template) ~~
+    }
+    chosen = data_choose_value_from_template(template)
     "Spawning {chosen['name']} in a {chosen['ship']}"
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.data import data_choose_value_from_template
 

--- a/mkdocs/docs/api/procedural/dmx.md
+++ b/mkdocs/docs/api/procedural/dmx.md
@@ -1,4 +1,4 @@
-# DMX system
+﻿# DMX system
 
 Control DMX lighting hardware connected to player consoles.
 
@@ -12,16 +12,15 @@ Each DMX channel maps to a light or group of lights. Channels 0–2 are conventi
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == red_alert ==
-    ~~ dmx_run_for_ship(SHIP_ID, lambda c: dmx_set_color(c, "#ff0000", 2, 10)) ~~
-
+    dmx_run_for_ship(SHIP_ID, lambda c: dmx_set_color(c, "#ff0000", 2, 10))
     == all_clear ==
-    ~~ dmx_run_for_ship(SHIP_ID, lambda c: dmx_set_color(c, "#00ff00", 1, 0)) ~~
+    dmx_run_for_ship(SHIP_ID, lambda c: dmx_set_color(c, "#00ff00", 1, 0))
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.dmx import dmx_run_for_ship, dmx_set_color, dmx_set_channel
 

--- a/mkdocs/docs/api/procedural/docking.md
+++ b/mkdocs/docs/api/procedural/docking.md
@@ -1,4 +1,4 @@
-# Docking system
+﻿# Docking system
 
 Manage proximity-based docking between player ships and NPCs.
 
@@ -25,30 +25,27 @@ The `DOCKING_PLAYER`, `DOCKING_PLAYER_ID`, `DOCKING_NPC`, and `DOCKING_NPC_ID` v
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == setup ==
-    ~~ docking_set_docking_logic(PLAYER_SET, STATION_SET, docking_logic) ~~
-
+    docking_set_docking_logic(PLAYER_SET, STATION_SET, docking_logic)
     == docking_logic ==
     ///enable
-    ~~ OK_SUCCESS ~~   # always allow docking
+    OK_SUCCESS   # always allow docking
 
     ///docked
-    ~~ set_engineering_value(DOCKING_PLAYER_ID, "energy", 1000) ~~
-    ~~ OK_SUCCESS ~~
-
+    set_engineering_value(DOCKING_PLAYER_ID, "energy", 1000)
+    OK_SUCCESS
     ///refit
-    ~~ hp = get_engineering_value(DOCKING_PLAYER_ID, "hullLevel") ~~
-    ~~ if hp >= 1.0: OK_SUCCESS ~~
-    ~~ set_engineering_value(DOCKING_PLAYER_ID, "hullLevel", hp + 0.01) ~~
-    ~~ OK_RUN_AGAIN ~~
-
+    hp = get_engineering_value(DOCKING_PLAYER_ID, "hullLevel")
+    if hp >= 1.0: OK_SUCCESS
+    set_engineering_value(DOCKING_PLAYER_ID, "hullLevel", hp + 0.01)
+    OK_RUN_AGAIN
     //signal/docked
     "Ship {DOCKING_PLAYER.name} has docked."
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.docking import docking_set_docking_logic
 

--- a/mkdocs/docs/api/procedural/execution.md
+++ b/mkdocs/docs/api/procedural/execution.md
@@ -1,4 +1,4 @@
-# The execution system
+﻿# The execution system
 
 Schedule and manage MAST tasks, jump between labels, and read task-scope variables.
 
@@ -18,7 +18,7 @@ Key concepts:
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == main ==
     await task_all(patrol_alpha, patrol_beta, patrol_gamma)
@@ -29,10 +29,10 @@ Key concepts:
     jump next_phase
 
     == setup ==
-    ~~ task_schedule(background_monitor) ~~
+    task_schedule(background_monitor)
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.execution import (
         task_schedule, task_all, task_any, task_cancel,

--- a/mkdocs/docs/api/procedural/grid.md
+++ b/mkdocs/docs/api/procedural/grid.md
@@ -1,4 +1,4 @@
-# Grid object system
+﻿# Grid object system
 
 Query, move, and theme engineering-grid objects on player ships.
 
@@ -18,17 +18,17 @@ The **theme system** controls icon appearance. `grid_get_grid_theme` and `grid_g
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == repair_run ==
-    ~~ damaged = grid_objects(SHIP_ID) & role("__damaged__") ~~
-    ~~ if len(damaged) == 0: jump done ~~
-    ~~ target_go = to_object(next(iter(damaged))) ~~
-    ~~ x, y, _ = grid_pos_data(target_go.id) ~~
-    ~~ grid_move(DAMCON_ID, int(x), int(y)) ~~
+    damaged = grid_objects(SHIP_ID) & role("__damaged__")
+    if len(damaged) == 0: jump done
+    target_go = to_object(next(iter(damaged)))
+    x, y, _ = grid_pos_data(target_go.id)
+    grid_move(DAMCON_ID, int(x), int(y))
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.grid import (
         grid_objects, grid_objects_at, grid_closest,

--- a/mkdocs/docs/api/procedural/internal_damage.md
+++ b/mkdocs/docs/api/procedural/internal_damage.md
@@ -1,4 +1,4 @@
-# The internal damage system
+﻿# The internal damage system
 
 Manage player ship engineering grid damage, repair, and ship destruction.
 
@@ -16,17 +16,16 @@ A typical damage event flows like this:
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     //damage/object /internal
-    ~~ grid_take_internal_damage_at(PLAYER_ID, EVENT.source_point) ~~
-
+    grid_take_internal_damage_at(PLAYER_ID, EVENT.source_point)
     //signal/player_ship_destroyed
     "The ship has been destroyed!"
     jump game_over
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.internal_damage import (
         grid_rebuild_grid_objects,

--- a/mkdocs/docs/api/procedural/inventory.md
+++ b/mkdocs/docs/api/procedural/inventory.md
@@ -1,4 +1,4 @@
-# The inventory system
+﻿# The inventory system
 
 A per-agent key→value store for arbitrary mission data.
 
@@ -17,19 +17,18 @@ Key functions:
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == setup ==
-    ~~ set_inventory_value(SHIP_ID, "HP", 100) ~~
-    ~~ set_inventory_value(SHIP_ID, "shield_online", True) ~~
-
+    set_inventory_value(SHIP_ID, "HP", 100)
+    set_inventory_value(SHIP_ID, "shield_online", True)
     == check_hp ==
-    ~~ hp = get_inventory_value(SHIP_ID, "HP", 0) ~~
+    hp = get_inventory_value(SHIP_ID, "HP", 0)
     "Ship HP: {hp}"
-    ~~ if hp <= 0: jump destroyed ~~
+    if hp <= 0: jump destroyed
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.inventory import (
         set_inventory_value, get_inventory_value,
@@ -51,8 +50,8 @@ Key functions:
 `Agent.SHARED` is a singleton agent used for global mission state. Use `get_shared_inventory_value` / `set_shared_inventory_value` as shorthands:
 
 ```
-~~ set_shared_inventory_value("GAME_STARTED", True) ~~
-~~ if get_shared_inventory_value("GAME_ENDED"): jump end_screen ~~
+set_shared_inventory_value("GAME_STARTED", True)
+if get_shared_inventory_value("GAME_ENDED"): jump end_screen
 ```
 
 In MAST you can also use the `shared` keyword:

--- a/mkdocs/docs/api/procedural/lifeform.md
+++ b/mkdocs/docs/api/procedural/lifeform.md
@@ -1,4 +1,4 @@
-# Life form system
+﻿# Life form system
 
 Spawn and manage grid-based crew members and lifeforms on the engineering console.
 
@@ -12,17 +12,16 @@ Damcon crew creation is handled automatically by `grid_restore_damcons` in the `
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == spawn_marine ==
-    ~~ marine = lifeform_spawn(SHIP_ID, "Marine", "marine_01", 3, 4, 2, "white", "crew,marine") ~~
-    ~~ grid_set_hp(SHIP_ID, marine, 6) ~~
-
+    marine = lifeform_spawn(SHIP_ID, "Marine", "marine_01", 3, 4, 2, "white", "crew,marine")
+    grid_set_hp(SHIP_ID, marine, 6)
     //signal/life_form_died
     "Crew member {LIFE_FORM_NAME} has perished!"
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.lifeform import lifeform_spawn
     from sbs_utils.procedural.internal_damage import grid_set_hp

--- a/mkdocs/docs/api/procedural/links.md
+++ b/mkdocs/docs/api/procedural/links.md
@@ -1,4 +1,4 @@
-# Links
+﻿# Links
 
 Uni-directional named associations between agents.
 
@@ -17,19 +17,18 @@ Links are uni-directional. `linked_to(ship_id, "consoles")` returns the consoles
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == setup ==
-    ~~ link(SHIP_ID, "escort_targets", FREIGHTER_ID) ~~
-    ~~ link(SHIP_ID, "escort_targets", TRANSPORT_ID) ~~
-
+    link(SHIP_ID, "escort_targets", FREIGHTER_ID)
+    link(SHIP_ID, "escort_targets", TRANSPORT_ID)
     == check ==
-    ~~ targets = linked_to(SHIP_ID, "escort_targets") ~~
-    ~~ alive = [t for t in targets if object_exists(t)] ~~
-    ~~ if len(alive) == 0: jump mission_complete ~~
+    targets = linked_to(SHIP_ID, "escort_targets")
+    alive = [t for t in targets if object_exists(t)]
+    if len(alive) == 0: jump mission_complete
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.links import link, unlink, linked_to, has_link_to
 

--- a/mkdocs/docs/api/procedural/maps.md
+++ b/mkdocs/docs/api/procedural/maps.md
@@ -1,4 +1,4 @@
-# Maps system
+﻿# Maps system
 
 Manage ``@map`` labels that define discoverable map waypoints and regions.
 
@@ -10,20 +10,19 @@ Map labels are declared in MAST with the `@map/path/name "Display"` syntax. They
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     @map/waypoints/alpha "Waypoint Alpha"
     @map/waypoints/beta "Waypoint Beta"
 
     == reveal_waypoints ==
-    ~~ map_schedule("waypoints/alpha") ~~
-    ~~ map_schedule("waypoints/beta") ~~
-
+    map_schedule("waypoints/alpha")
+    map_schedule("waypoints/beta")
     == waypoints/alpha ==
-    ~~ set_map_pos(5000, 0, 3000) ~~
+    set_map_pos(5000, 0, 3000)
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.maps import map_get, map_schedule
 

--- a/mkdocs/docs/api/procedural/media.md
+++ b/mkdocs/docs/api/procedural/media.md
@@ -1,4 +1,4 @@
-# The media system
+﻿# The media system
 
 Schedule skybox and music ``@media`` labels defined in MAST.
 
@@ -12,18 +12,18 @@ Use `skybox_schedule` / `music_schedule` as convenient wrappers when you already
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     @media/skybox/nebula "Nebula"
     @media/skybox/deep_space "Deep Space"
     @media/music/battle "Battle Music"
 
     == setup ==
-    ~~ skybox_schedule_random() ~~
-    ~~ music_schedule("battle") ~~
+    skybox_schedule_random()
+    music_schedule("battle")
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.media import (
         skybox_schedule, skybox_schedule_random,

--- a/mkdocs/docs/api/procedural/mission.md
+++ b/mkdocs/docs/api/procedural/mission.md
@@ -1,4 +1,4 @@
-# The mission system
+﻿# The mission system
 
 Structured mission lifecycle runner with `init`, `start`, `objective`, and `complete` phases.
 
@@ -20,32 +20,28 @@ This is the same pattern used by the built-in objective system — use `mission_
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == main ==
-    ~~ mission_run(escort_mission) ~~
-
+    mission_run(escort_mission)
     == escort_mission ==
     ///init
-    ~~ spawn_escort_target() ~~
-
+    spawn_escort_target()
     ///start
     "Escort the freighter to the station."
 
     ///objective
-    ~~ if freighter_arrived(): OK_SUCCESS ~~
-    ~~ OK_RUN_AGAIN ~~
-
+    if freighter_arrived(): OK_SUCCESS
+    OK_RUN_AGAIN
     ///abort
-    ~~ if freighter_destroyed(): FAIL_END ~~
-    ~~ OK_RUN_AGAIN ~~
-
+    if freighter_destroyed(): FAIL_END
+    OK_RUN_AGAIN
     ///complete
     "Mission complete! The freighter has arrived safely."
-    ~~ OK_SUCCESS ~~
+    OK_SUCCESS
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.mission import mission_run
 

--- a/mkdocs/docs/api/procedural/modifiers.md
+++ b/mkdocs/docs/api/procedural/modifiers.md
@@ -1,4 +1,4 @@
-# Modifiers system
+﻿# Modifiers system
 
 Apply temporary or persistent stat modifications to agents.
 
@@ -12,16 +12,15 @@ Modifiers are used internally by the upgrade system to track stat changes applie
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == apply_speed_boost ==
-    ~~ modifier_add(SHIP_ID, "topSpeed", 5, "speed_upgrade") ~~
-
+    modifier_add(SHIP_ID, "topSpeed", 5, "speed_upgrade")
     == remove_speed_boost ==
-    ~~ modifier_remove(SHIP_ID, "topSpeed", "speed_upgrade") ~~
+    modifier_remove(SHIP_ID, "topSpeed", "speed_upgrade")
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.modifiers import modifier_add, modifier_remove, modifier_clear
 

--- a/mkdocs/docs/api/procedural/objective.md
+++ b/mkdocs/docs/api/procedural/objective.md
@@ -1,4 +1,4 @@
-# The objective module
+﻿# The objective module
 
 The tick scheduler that drives brains, docking, and other background systems.
 
@@ -10,16 +10,15 @@ Mission scripts rarely call objective functions directly — `brain_schedule`, `
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == setup ==
-    ~~ objective_add(check_mission_state) ~~
-
+    objective_add(check_mission_state)
     == teardown ==
-    ~~ objective_remove(check_mission_state) ~~
+    objective_remove(check_mission_state)
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.objective import objective_add, objective_remove, objective_schedule
 

--- a/mkdocs/docs/api/procedural/popup.md
+++ b/mkdocs/docs/api/procedural/popup.md
@@ -1,4 +1,4 @@
-# The popup system
+﻿# The popup system
 
 Context menus shown when a player clicks or hold-clicks an object in the 2D/3D views.
 
@@ -12,16 +12,16 @@ The variables `SCIENCE_ORIGIN_ID`, `SCIENCE_SELECTED_ID`, and `SCIENCE_POPUP_ID`
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     //popup/science
     * "Scan"
-        ~~ signal_emit("scan_object", {"TARGET_ID": SCIENCE_SELECTED_ID}) ~~
+        signal_emit("scan_object", {"TARGET_ID": SCIENCE_SELECTED_ID})
     * "Attack"
-        ~~ target(SHIP_ID, SCIENCE_SELECTED_ID) ~~
+        target(SHIP_ID, SCIENCE_SELECTED_ID)
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.popup import popup_navigate
 

--- a/mkdocs/docs/api/procedural/prefab.md
+++ b/mkdocs/docs/api/procedural/prefab.md
@@ -1,4 +1,4 @@
-# The prefab system
+﻿# The prefab system
 
 Reusable MAST labels that spawn entities and configure them in one call.
 
@@ -14,18 +14,17 @@ A `PrefabAll` promise (returned from grouping multiple `prefab_spawn` calls via 
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == spawn_enemy_wave ==
-    ~~ prefab_spawn(enemy_prefab, {"START_X": 5000, "START_Z": 3000, "NAME": "Raider #"}) ~~
-    ~~ prefab_spawn(enemy_prefab, {"START_X": 5500, "START_Z": 3000, "NAME": "Raider #"}) ~~
-
+    prefab_spawn(enemy_prefab, {"START_X": 5000, "START_Z": 3000, "NAME": "Raider #"})
+    prefab_spawn(enemy_prefab, {"START_X": 5500, "START_Z": 3000, "NAME": "Raider #"})
     == enemy_prefab ==
-    ~~ id = spawn_enemy(START_X, START_Y, START_Z, NAME) ~~
-    ~~ add_role(id, "enemy") ~~
+    id = spawn_enemy(START_X, START_Y, START_Z, NAME)
+    add_role(id, "enemy")
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.prefab import prefab_spawn, prefab_extends, prefab_autoname
 

--- a/mkdocs/docs/api/procedural/promise_functions.md
+++ b/mkdocs/docs/api/procedural/promise_functions.md
@@ -1,4 +1,4 @@
-# Promise functions
+﻿# Promise functions
 
 Awaitable promise helpers for coordinating parallel async operations.
 
@@ -12,16 +12,16 @@ Promises are objects returned by `await`-able functions. They represent a value 
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == run_parallel ==
-    ~~ p1 = task_schedule(patrol_alpha) ~~
-    ~~ p2 = task_schedule(patrol_beta) ~~
+    p1 = task_schedule(patrol_alpha)
+    p2 = task_schedule(patrol_beta)
     await promise_all(p1, p2)
     "Both patrols complete."
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.promise_functions import promise_all, promise_any, promise_is_done
 

--- a/mkdocs/docs/api/procedural/query.md
+++ b/mkdocs/docs/api/procedural/query.md
@@ -1,4 +1,4 @@
-# The query module
+﻿# The query module
 
 Resolve and convert agent IDs, objects, and collections between formats.
 
@@ -18,14 +18,14 @@ The `is_*` functions test which ID category a value belongs to. This matters bec
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
-    ~~ id = to_id(closest_enemy) ~~
-    ~~ obj = to_object(id) ~~
-    ~~ if object_exists(id): target(SHIP_ID, id) ~~
+    id = to_id(closest_enemy)
+    obj = to_object(id)
+    if object_exists(id): target(SHIP_ID, id)
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.query import (
         to_id, to_object, to_set, object_exists,

--- a/mkdocs/docs/api/procedural/quest.md
+++ b/mkdocs/docs/api/procedural/quest.md
@@ -1,4 +1,4 @@
-# The quest system
+﻿# The quest system
 
 Track mission objectives and quest states attached to any agent or shared globally.
 
@@ -21,18 +21,17 @@ Quests can be attached to a specific player ship, a specific client console, or 
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == setup ==
-    ~~ quest_add(SHIP_ID, "patrol", "Patrol Sector 7", "Keep the peace in sector 7.") ~~
-    ~~ quest_set_key(SHIP_ID, "patrol", "state", QuestState.ACTIVE) ~~
-
+    quest_add(SHIP_ID, "patrol", "Patrol Sector 7", "Keep the peace in sector 7.")
+    quest_set_key(SHIP_ID, "patrol", "state", QuestState.ACTIVE)
     == on_patrol_done ==
-    ~~ quest_complete(SHIP_ID, "patrol") ~~
-    ~~ quest_set_key(SHIP_ID, "patrol", "state", QuestState.COMPLETE) ~~
+    quest_complete(SHIP_ID, "patrol")
+    quest_set_key(SHIP_ID, "patrol", "state", QuestState.COMPLETE)
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.quest import quest_add, quest_set_key, quest_complete, QuestState
 
@@ -46,22 +45,23 @@ Quests can be attached to a specific player ship, a specific client console, or 
 ## Displaying quests
 
 ```
-~~ items = quest_flatten_list() ~~
+items = quest_flatten_list()
 gui_property_list_box(items, style="area:0,0,100,100;")
 ```
 
 ## Loading quests from YAML
 
 ```
-~~ quest_add_yaml(SHIP_ID, ~~
+yaml_text = """
 patrol:
-  display_text: "Patrol Sector 7"
-  description: "Keep the peace."
+  display_text: Patrol Sector 7
+  description: Keep the peace.
   state: ACTIVE
 rescue:
-  display_text: "Rescue the crew"
-  description: "Find the survivors."
-~~) ~~
+  display_text: Rescue the crew
+  description: Find the survivors.
+"""
+quest_add_yaml(SHIP_ID, yaml_text)
 ```
 
 ## API

--- a/mkdocs/docs/api/procedural/roles.md
+++ b/mkdocs/docs/api/procedural/roles.md
@@ -1,4 +1,4 @@
-# The roles system
+﻿# The roles system
 
 Tag agents with named labels for targeting, querying, and conditional logic.
 
@@ -18,21 +18,19 @@ Common uses:
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == setup ==
-    ~~ add_role(ENEMY_ID, "target_priority") ~~
-
+    add_role(ENEMY_ID, "target_priority")
     == targeting ==
-    ~~ nearest = closest(SHIP_ID, role("target_priority")) ~~
-    ~~ target(SHIP_ID, nearest) ~~
-
+    nearest = closest(SHIP_ID, role("target_priority"))
+    target(SHIP_ID, nearest)
     == on_explosion ==
-    ~~ add_role(SHIP_ID, "exploded") ~~
-    ~~ remove_role(SHIP_ID, "target_priority") ~~
+    add_role(SHIP_ID, "exploded")
+    remove_role(SHIP_ID, "target_priority")
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.roles import add_role, remove_role, has_role, role
 
@@ -50,9 +48,9 @@ Common uses:
 ## Using with targeting
 
 ```
-~~ close = closest(SHIP_ID, role("spy")) ~~
-~~ close = closest(SHIP_ID, role("station")) ~~   # ship class names are roles
-~~ close = closest(SHIP_ID, role("tsn")) ~~        # side is also a role
+close = closest(SHIP_ID, role("spy"))
+close = closest(SHIP_ID, role("station"))   # ship class names are roles
+close = closest(SHIP_ID, role("tsn"))        # side is also a role
 ```
 
 ## System roles

--- a/mkdocs/docs/api/procedural/routes.md
+++ b/mkdocs/docs/api/procedural/routes.md
@@ -1,4 +1,4 @@
-# The routes module
+﻿# The routes module
 
 Register and manage MAST route handlers from Python.
 
@@ -12,16 +12,15 @@ See the [Routes overview](../../../mast/routes/index.md) for the full list of ro
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == enable_damage_handler ==
-    ~~ route_schedule("//damage/object /internal", on_internal_damage) ~~
-
+    route_schedule("//damage/object /internal", on_internal_damage)
     == on_internal_damage ==
-    ~~ grid_take_internal_damage_at(PLAYER_ID, EVENT.source_point) ~~
+    grid_take_internal_damage_at(PLAYER_ID, EVENT.source_point)
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.routes import route_schedule, route_clear
 

--- a/mkdocs/docs/api/procedural/science.md
+++ b/mkdocs/docs/api/procedural/science.md
@@ -1,4 +1,4 @@
-# The science module
+﻿# The science module
 
 Control and respond to science console scanning and intel display.
 
@@ -12,21 +12,19 @@ The `//focus/science` route fires when the science console focuses on an object.
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == setup ==
-    ~~ science_add_scan_data(ENEMY_ID, "Ship Class", "Battlecruiser") ~~
-    ~~ science_add_scan_data(ENEMY_ID, "Threat Level", "High") ~~
-    ~~ science_add_scan_data(ENEMY_ID, "Shields", "Online") ~~
-
+    science_add_scan_data(ENEMY_ID, "Ship Class", "Battlecruiser")
+    science_add_scan_data(ENEMY_ID, "Threat Level", "High")
+    science_add_scan_data(ENEMY_ID, "Shields", "Online")
     //focus/science
-    ~~ if EVENT.selected_id == ENEMY_ID: jump enemy_scanned ~~
-
+    if EVENT.selected_id == ENEMY_ID: jump enemy_scanned
     == enemy_scanned ==
-    ~~ comms_broadcast(SHIP_ID, "Science: Enemy battlecruiser detected!", "red") ~~
+    comms_broadcast(SHIP_ID, "Science: Enemy battlecruiser detected!", "red")
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.science import science_add_scan_data, science_clear_scan_data
 

--- a/mkdocs/docs/api/procedural/settings.md
+++ b/mkdocs/docs/api/procedural/settings.md
@@ -1,4 +1,4 @@
-# The settings system
+﻿# The settings system
 
 Mission configuration defaults loaded from `settings.yaml` (or legacy `setup.json`).
 
@@ -13,15 +13,15 @@ Common use-cases:
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == setup ==
-    ~~ settings = settings_get_defaults() ~~
-    ~~ difficulty = settings.get("DIFFICULTY", 5) ~~
+    settings = settings_get_defaults()
+    difficulty = settings.get("DIFFICULTY", 5)
     "Difficulty is {difficulty}"
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.settings import settings_get_defaults, settings_add_defaults
 

--- a/mkdocs/docs/api/procedural/ship_data.md
+++ b/mkdocs/docs/api/procedural/ship_data.md
@@ -1,4 +1,4 @@
-# The ship_data module
+﻿# The ship_data module
 
 Load and query the ship-definition JSON database.
 
@@ -12,16 +12,16 @@ The database is loaded lazily and cached. Mission scripts do not normally need t
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
-    ~~ ship_db = get_ship_data("tsn_battle_cruiser") ~~
-    ~~ display_name = ship_db.get("name", "Unknown") ~~
+    ship_db = get_ship_data("tsn_battle_cruiser")
+    display_name = ship_db.get("name", "Unknown")
     "Spawning a {display_name}"
 
-    ~~ speed = get_ship_data_value("tsn_battle_cruiser", "topSpeed", 10) ~~
+    speed = get_ship_data_value("tsn_battle_cruiser", "topSpeed", 10)
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.ship_data import (
         get_ship_data, get_all_ship_data, get_ship_data_value,

--- a/mkdocs/docs/api/procedural/sides.md
+++ b/mkdocs/docs/api/procedural/sides.md
@@ -1,4 +1,4 @@
-# Sides system
+﻿# Sides system
 
 Query and manage the faction/allegiance side of space objects.
 
@@ -16,18 +16,17 @@ tsn_stations = broad_test_around(pos, 5000) & role("tsn") & role("station")
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == check_side ==
-    ~~ if get_side(TARGET_ID) == "tsc": jump enemy_detected ~~
-    ~~ if get_side(TARGET_ID) == "tsn": jump friendly_detected ~~
-
+    if get_side(TARGET_ID) == "tsc": jump enemy_detected
+    if get_side(TARGET_ID) == "tsn": jump friendly_detected
     == defect ==
-    ~~ side_set(NPC_ID, "tsn") ~~
+    side_set(NPC_ID, "tsn")
     "Enemy ship has defected to TSN!"
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.sides import side_set, get_side, get_side_for_display
 

--- a/mkdocs/docs/api/procedural/signal.md
+++ b/mkdocs/docs/api/procedural/signal.md
@@ -1,4 +1,4 @@
-# The signal system
+﻿# The signal system
 
 Emit named events and register handlers that fire when those events occur.
 
@@ -12,17 +12,16 @@ Data passed to `signal_emit` becomes task variables in the handler. By conventio
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == patrol ==
-    ~~ signal_emit("enemy_spotted", {"ENEMY_ID": enemy_id, "SHIP_ID": SHIP_ID}) ~~
-
+    signal_emit("enemy_spotted", {"ENEMY_ID": enemy_id, "SHIP_ID": SHIP_ID})
     //signal/enemy_spotted
     "Enemy spotted by {get_inventory_value(SHIP_ID, 'name')}!"
-    ~~ target(SHIP_ID, ENEMY_ID) ~~
+    target(SHIP_ID, ENEMY_ID)
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.signal import signal_emit, signal_connect, signal_disconnect
 

--- a/mkdocs/docs/api/procedural/space_objects.md
+++ b/mkdocs/docs/api/procedural/space_objects.md
@@ -1,4 +1,4 @@
-# The space_objects module
+﻿# The space_objects module
 
 Spatial queries, targeting, positioning, and engineering value access for space objects.
 
@@ -16,19 +16,18 @@ The space objects module provides the main tools for working with the simulation
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == patrol ==
-    ~~ enemies = broad_test_around(get_pos(SHIP_ID), 2000) & role("enemy") ~~
-    ~~ nearest = closest(SHIP_ID, enemies) ~~
-    ~~ if nearest: target(SHIP_ID, nearest) ~~
-
+    enemies = broad_test_around(get_pos(SHIP_ID), 2000) & role("enemy")
+    nearest = closest(SHIP_ID, enemies)
+    if nearest: target(SHIP_ID, nearest)
     == recharge ==
-    ~~ set_engineering_value(SHIP_ID, "energy", 1000) ~~
-    ~~ set_pos(SHIP_ID, 0, 0, 0) ~~
+    set_engineering_value(SHIP_ID, "energy", 1000)
+    set_pos(SHIP_ID, 0, 0, 0)
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.space_objects import (
         broad_test_around, closest, target, clear_target,

--- a/mkdocs/docs/api/procedural/spawn.md
+++ b/mkdocs/docs/api/procedural/spawn.md
@@ -1,4 +1,4 @@
-# The spawn module
+﻿# The spawn module
 
 Create and delete space objects, NPCs, grid objects, and client agents.
 
@@ -17,17 +17,16 @@ Key helpers:
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == spawn_enemies ==
-    ~~ e1 = spawn_npc("Hive Emperor", "tsc", 5000, 0, 3000, "Raider 01") ~~
-    ~~ add_role(e1, "enemy") ~~
-    ~~ brain_add(e1, patrol_label) ~~
-
-    ~~ station = spawn_station("Generic Station", "tsn", 0, 0, 0, "Starbase Alpha") ~~
+    e1 = spawn_npc("Hive Emperor", "tsc", 5000, 0, 3000, "Raider 01")
+    add_role(e1, "enemy")
+    brain_add(e1, patrol_label)
+    station = spawn_station("Generic Station", "tsn", 0, 0, 0, "Starbase Alpha")
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.spawn import spawn_npc, spawn_station, delete_object
 

--- a/mkdocs/docs/api/procedural/terrain.md
+++ b/mkdocs/docs/api/procedural/terrain.md
@@ -1,4 +1,4 @@
-# Terrain system
+﻿# Terrain system
 
 Spawn and manage terrain objects: nebulae, asteroids, black holes, and anomalies.
 
@@ -10,15 +10,15 @@ Use `terrain_spawn` as the general-purpose call. Convenience wrappers exist for 
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == place_terrain ==
-    ~~ nebula = terrain_spawn("nebula2", 1000, 0, 2000) ~~
-    ~~ asteroid = terrain_spawn("asteroid", 3000, 0, 1000) ~~
-    ~~ add_role(nebula, "safe_zone") ~~
+    nebula = terrain_spawn("nebula2", 1000, 0, 2000)
+    asteroid = terrain_spawn("asteroid", 3000, 0, 1000)
+    add_role(nebula, "safe_zone")
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.terrain import terrain_spawn
     from sbs_utils.procedural.space_objects import delete_object

--- a/mkdocs/docs/api/procedural/timers.md
+++ b/mkdocs/docs/api/procedural/timers.md
@@ -1,4 +1,4 @@
-# Timers and counters
+﻿# Timers and counters
 
 Delay execution and count events with awaitable promises.
 
@@ -20,23 +20,22 @@ await count_goal("enemies_killed", 10)
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == timed_event ==
     "Reactor will detonate in 30 seconds!"
     await delay_sim(seconds=30)
     "The reactor has detonated!"
-    ~~ explode_player_ship(STATION_ID) ~~
-
+    explode_player_ship(STATION_ID)
     == count_kills ==
     await count_goal("kills", 5)
     "You have destroyed 5 enemies. Well done!"
 
     //signal/enemy_destroyed
-    ~~ increment_count("kills") ~~
+    increment_count("kills")
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.timers import delay_sim, delay, count_goal, increment_count, reset_count
 

--- a/mkdocs/docs/api/procedural/torpedoes.md
+++ b/mkdocs/docs/api/procedural/torpedoes.md
@@ -1,4 +1,4 @@
-# The torpedoes system
+﻿# The torpedoes system
 
 Define custom torpedo types and manage ship torpedo loadouts.
 
@@ -12,16 +12,16 @@ The torpedo system is actively evolving — new `warhead` and `behavior` values 
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == setup ==
-    ~~ torpedo_type("emp", gui_text="EMP Pulse", warhead="reduce_shields", damage=10, speed=15) ~~
-    ~~ torpedo_type("cluster", gui_text="Cluster Bomb", warhead="blast", blast_radius=1500, damage=50) ~~
-    ~~ torpedo_make_available(SHIP_ID, "emp", count=4) ~~
-    ~~ torpedo_make_available(SHIP_ID, "cluster", count=2) ~~
+    torpedo_type("emp", gui_text="EMP Pulse", warhead="reduce_shields", damage=10, speed=15)
+    torpedo_type("cluster", gui_text="Cluster Bomb", warhead="blast", blast_radius=1500, damage=50)
+    torpedo_make_available(SHIP_ID, "emp", count=4)
+    torpedo_make_available(SHIP_ID, "cluster", count=2)
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.torpedoes import (
         torpedo_type, torpedo_make_available, torpedo_make_unavailable,

--- a/mkdocs/docs/api/procedural/upgrades.md
+++ b/mkdocs/docs/api/procedural/upgrades.md
@@ -1,4 +1,4 @@
-# The upgrades system
+﻿# The upgrades system
 
 Apply MAST-driven ability labels to ships or other agents as activatable upgrades.
 
@@ -10,16 +10,15 @@ Use `upgrade_add` with `activate=False` to pre-register upgrades (e.g. at ship s
 
 ## Quick example
 
-=== "MAST"
+=== ":mast-icon: {{ab.m}}"
     ```
     == setup ==
-    ~~ upgrade_add(SHIP_ID, shield_boost_label, activate=True) ~~
-
+    upgrade_add(SHIP_ID, shield_boost_label, activate=True)
     == shield_boost_label ==
-    ~~ set_engineering_value(SHIP_ID, "shieldStrengthFront", 200) ~~
+    set_engineering_value(SHIP_ID, "shieldStrengthFront", 200)
     ```
 
-=== "Python"
+=== ":simple-python: {{ab.pm}}"
     ```python
     from sbs_utils.procedural.upgrades import upgrade_add, upgrade_remove_all
 


### PR DESCRIPTION
## Summary

- Added 11 missing procedural API pages: `brain`, `data`, `internal_damage`, `media`, `mission`, `popup`, `prefab`, `quest`, `settings`, `torpedoes`, `upgrades`
- Improved all 26 existing bare-shell pages with overview prose, MAST/Python tabbed examples, and parameter tables
- Created `mast/prefabs.md` to fix a broken nav link
- Updated `mkdocs.yml` nav to include all new pages
- Added missing `brains_run_all` docstring to `brain.py`

## Style fixes

- Tab headers now use icon syntax: `:mast-icon: {{ab.m}}` and `:simple-python: {{ab.pm}}`
- Removed `~~` wrappers from all MAST code examples (only needed when the parser fails, not for plain function calls)

## Test plan

- [ ] Run `mkdocs build` or `mkdocs serve` and verify all procedural pages render without errors
- [ ] Check that tabbed code blocks show MAST and Python icons in headers
- [ ] Verify MAST examples have no stray `~~` wrappers
- [ ] Confirm nav links to all new pages resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)